### PR TITLE
keep fasta in memory

### DIFF
--- a/genomelake/extractors.py
+++ b/genomelake/extractors.py
@@ -91,13 +91,12 @@ class FastaExtractor(BaseExtractor):
     def __init__(self, datafile, use_strand=False, **kwargs):
         super(FastaExtractor, self).__init__(datafile, **kwargs)
         self.use_strand = use_strand
+        self.fasta = FastaFile(self._datafile)
 
-    def _extract(self, intervals, out, **kwargs):
-        fasta = FastaFile(self._datafile)
-
+    def _extract(self, intervals, out, **kwargs):    
         for index, interval in enumerate(intervals):
-            seq = fasta.fetch(str(interval.chrom), interval.start,
-                              interval.stop)
+            seq = self.fasta.fetch(str(interval.chrom), interval.start,
+                                       interval.stop)
             one_hot_encode_sequence(seq, out[index, :, :])
 
             # reverse-complement seq the negative strand


### PR DESCRIPTION
Made the FastaFile object an instance variable of the fasta extractor. By doing so, the file is only opened once, on construction of the extractor instead of on every call. This significantly improves performance when this function called many times. If this is behavior is not always the preferred one, we could introduce a flag indicating which type of behavior is preferred (but for simplicity and the fact that genomelake is tailored towards machine learning, probably performance of data retrieval is almost always most important).